### PR TITLE
Allow toggling status bar button

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,11 @@
 					},
 					"description": "The paths to be treated as server-sided directories. Overrides rojo if enabled."
 				},
+				"roblox-ts.status.show": {
+					"type": "boolean",
+					"default": true,
+					"description": "Whether to show the status button."
+				},
 				"roblox-ts.command.parameters": {
 					"type": "array",
 					"default": ["-w"],

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 					},
 					"description": "The paths to be treated as server-sided directories. Overrides rojo if enabled."
 				},
-				"roblox-ts.status.show": {
+				"roblox-ts.command.status.show": {
 					"type": "boolean",
 					"default": true,
 					"description": "Whether to show the status button."

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.workspace.onDidChangeConfiguration((e) => {
 		if (e.affectsConfiguration("roblox-ts")) {
 			configurePlugin(api);
+			updateStatusButtonVisibility();
 		}
 	}, undefined, context.subscriptions);
 
@@ -83,6 +84,14 @@ export async function activate(context: vscode.ExtensionContext) {
 		statusBarItem.text = "$(debug-start) roblox-ts";
 		statusBarItem.command = "roblox-ts.start";
 	};
+
+	const updateStatusButtonVisibility = () => {
+		if (vscode.workspace.getConfiguration('roblox-ts.status').get('show', true)) {
+			statusBarItem.show();
+		} else {
+			statusBarItem.hide();
+		}
+	}
 
 	let compilerProcess: childProcess.ChildProcessWithoutNullStreams;
 	let compilerPendingExit = false;
@@ -165,7 +174,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(outputChannel);
 
 	statusBarDefaultState();
-	statusBarItem.show();
+	updateStatusButtonVisibility();
 
 	vscode.commands.executeCommand('setContext', 'roblox-ts:inSrcDir', vscode.window.activeTextEditor?.document.uri.fsPath ?? false);
 	vscode.commands.executeCommand('setContext', 'roblox-ts:compilerActive', false);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	};
 
 	const updateStatusButtonVisibility = () => {
-		if (vscode.workspace.getConfiguration('roblox-ts.status').get('show', true)) {
+		if (vscode.workspace.getConfiguration('roblox-ts.command.status').get('show', true)) {
 			statusBarItem.show();
 		} else {
 			statusBarItem.hide();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,7 +91,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		} else {
 			statusBarItem.hide();
 		}
-	}
+	};
 
 	let compilerProcess: childProcess.ChildProcessWithoutNullStreams;
 	let compilerPendingExit = false;


### PR DESCRIPTION
This allows the status bar button to be enabled/disabled per workspace in the configuration