### PR TITLE
Make colors work with .tsx files

### DIFF
--- a/src/colorizePrint.ts
+++ b/src/colorizePrint.ts
@@ -51,7 +51,7 @@ function extractTriColor(match: RegExpMatchArray): ColorArray {
 }
 
 export function makeColorProvider() {
-	return vscode.languages.registerColorProvider("typescript", {
+	const provider: vscode.DocumentColorProvider = {
 		provideColorPresentations: (color, context, token) => {
 			const text = context.document.getText(context.range);
 
@@ -91,5 +91,10 @@ export function makeColorProvider() {
 
 			return result;
 		}
-	});
+	};
+
+	return [
+		vscode.languages.registerColorProvider('typescript', provider),
+		vscode.languages.registerColorProvider('typescriptreact', provider)
+	];
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -176,7 +176,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	const colorConfiguration = vscode.workspace.getConfiguration("roblox-ts.color-picker");
 	if (colorConfiguration.get("enabled", true)) {
-		context.subscriptions.push(makeColorProvider());
+		makeColorProvider().forEach(provider => context.subscriptions.push(provider));
 	}
 
 	statusBarDefaultState();


### PR DESCRIPTION
Oops, turns out .tsx is called TypeScriptReact and the TypeScript color provider does not parse TypeScriptReact files